### PR TITLE
stacks removed from bags do not persist on screen forever

### DIFF
--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -249,6 +249,11 @@
 	if(!uses_charge)
 		amount -= used
 		if (amount <= 0)
+			// bug that only seems to happen when you click stacks stored in a bag, they remain onscreen till GCed randomly
+			if(istype( src.loc, /obj/item/weapon/storage/))
+				// so lets just remove them...
+				var/obj/item/weapon/storage/holder = src.loc
+				holder.remove_from_storage( src, null)
 			qdel(src) //should be safe to qdel immediately since if someone is still using this stack it will persist for a little while longer
 		update_icon()
 		return 1


### PR DESCRIPTION
Stacks still had a stale reference in the bag itself, and couldn't be removed from the screen correctly. Now dumps from bag like cig boxes dump their cigs etc. 