### PR TITLE
Changes Observer Mouse to Jil

### DIFF
--- a/code/__defines/span_vr.dm
+++ b/code/__defines/span_vr.dm
@@ -10,7 +10,7 @@
 
 #define span_comradio(str) ("<span class='comradio'>" + str + "</span>")
 #define span_syndradio(str) ("<span class='syndradio'>" + str + "</span>")
-#define span_centradio(str) ("<span class='centradio'>" + str + "</span>"
+#define span_centradio(str) ("<span class='centradio'>" + str + "</span>")
 #define span_airadio(str) ("<span class='airadio'>" + str + "</span>")
 #define span_entradio(str) ("<span class='entradio'>" + str + "</span>")
 
@@ -18,7 +18,7 @@
 #define span_engradio(str) ("<span class='engradio'>" + str + "</span>")
 #define span_medradio(str) ("<span class='medradio'>" + str + "</span>")
 #define span_sciradio(str) ("<span class='sciradio'>" + str + "</span>")
-#define span_supradio(str) ("<span class='supradio'>" + str + "</span>"
+#define span_supradio(str) ("<span class='supradio'>" + str + "</span>")
 #define span_srvradio(str) ("<span class='srvradio'>" + str + "</span>")
 #define span_expradio(str) ("<span class='expradio'>" + str + "</span>")
 

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -1042,14 +1042,14 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			found_vents.Add(v)
 	if(found_vents.len)
 		vent_found = pick(found_vents)
-		host = new /mob/living/simple_mob/animal/passive/mouse(vent_found)
+		host = new /mob/living/simple_mob/vore/alienanimals/jil(vent_found)
 	else
 		to_chat(src, "<span class='warning'>Unable to find any unwelded vents to spawn mice at.</span>")
 
 	if(host)
 		if(config.uneducated_mice)
 			host.universal_understand = 0
-		announce_ghost_joinleave(src, 0, "They are now a mouse.")
+		announce_ghost_joinleave(src, 0, "They are now a Jil.")
 		host.ckey = src.ckey
 		host.add_ventcrawl(vent_found)
-		to_chat(host, "<span class='info'>You are now a mouse. Try to avoid interaction with players, and do not give hints away that you are more than a simple rodent.</span>")
+		to_chat(host, "<span class='danger'>You are now a Jil, a fluffy little thief that seeks to steal anything you can grab, and bring it back to your nest. Be warned, the crew might not like you taking their things.</span>")


### PR DESCRIPTION
What it says on the tin.
Changes the mob you're forced into when observing from mouse to jil, and adjusts the dead chat and player chat notifs to reflect this.

Also closes some pointlessly open brackets I found in the span classes because it was bugging my OCD.